### PR TITLE
Initialize README for SuperToken wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,16 @@
+# Send Token V1
+
+Initial repository README.
+
+Notes:
+- Tooling and test commands are introduced in later commits when the
+  project is scaffolded.
+- After scaffolding is in place (package.json, hardhat.config.ts), you can
+  run tests using Hardhat, e.g.:
+
+```sh
+# after scaffold
+bunx hardhat test
+# or when a package.json script exists
+bun run test
+```


### PR DESCRIPTION
Why:
Introduce initial README to describe the SuperToken wrapper
and repository scope so contributors have context.

Test plan:
- Open README.md and verify content renders.