### PR TITLE
Rename package name

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@0xsend/send-token-upgrade",
+  "name": "@0xsend/super-send-token",
   "version": "0.0.3",
   "devDependencies": {
     "@nomicfoundation/hardhat-toolbox-viem": "^3.0.0",


### PR DESCRIPTION
Why:
Ensure the package name matches the repository purpose and
avoids conflicts in local toolchains.

Test plan:
- Inspect package.json name field.
- bun install completes without warnings.