### PR TITLE
Add wrapper create/attach script

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,16 @@ Scripts and flows
   ```sh
   bun run test
   ```
-- Local deploy orchestration (placeholder until PR4 adds wrapper script):
+- Local wrapper discovery/creation (PR4):
+  - Discover existing wrapper or create if not present (set CREATE_WRAPPER=true):
+    ```sh
+    CREATE_WRAPPER=true bunx hardhat run scripts/wrapper/create.ts --network anvil
+    ```
+  - Or against base/mainnet:
+    ```sh
+    bunx hardhat run scripts/wrapper/create.ts --network base
+    ```
+- Local deploy orchestration (anvil state helper):
   ```sh
   ./bin/anvil-deploy
   ```

--- a/scripts/wrapper/create.ts
+++ b/scripts/wrapper/create.ts
@@ -1,0 +1,116 @@
+import hre from "hardhat";
+import { getConfig } from "../../config/superfluid";
+import fs from "fs/promises";
+import path from "node:path";
+import { getContract } from "viem";
+// Rule 3 references (we mirror official examples; no custom Solidity):
+// - SuperTokenFactory ABI and interface: https://github.com/superfluid-finance/protocol-monorepo/blob/dev/packages/ethereum-contracts/contracts/superfluid/SuperTokenFactory.sol
+// - ISuperToken interface: https://github.com/superfluid-finance/protocol-monorepo/blob/dev/packages/ethereum-contracts/contracts/interfaces/superfluid/ISuperToken.sol
+// - Hardhat + Viem usage: https://github.com/NomicFoundation/hardhat-viem
+
+// Import ABIs from the official Superfluid package (installed as a dev dependency).
+// We use the truffle JSON artifacts for ABIs only.
+import SuperTokenFactoryJson from "@superfluid-finance/ethereum-contracts/build/truffle/SuperTokenFactory.json" assert { type: "json" };
+import ISuperTokenJson from "@superfluid-finance/ethereum-contracts/build/truffle/ISuperToken.json" assert { type: "json" };
+
+async function readJson(file: string): Promise<any | null> {
+  try { return JSON.parse(await fs.readFile(file, "utf8")); } catch { return null; }
+}
+
+async function writeJson(file: string, data: any) {
+  await fs.mkdir(path.dirname(file), { recursive: true });
+  await fs.writeFile(file, JSON.stringify(data, null, 2));
+}
+
+async function main() {
+  const publicClient = await hre.viem.getPublicClient();
+  const [walletClient] = await hre.viem.getWalletClients();
+  if (!walletClient) throw new Error("No wallet client available. Configure accounts for the selected network.");
+  const account = walletClient.account!;
+
+  const chainId = await publicClient.getChainId();
+  const cfg = getConfig(chainId);
+
+  const deploymentsPath = path.resolve(__dirname, "..", "..", "deployments", `wrapper.${chainId}.json`);
+  const existing = await readJson(deploymentsPath);
+
+  const factoryAbi = SuperTokenFactoryJson.abi as any[];
+  const superTokenAbi = ISuperTokenJson.abi as any[];
+
+  const log = (...args: any[]) => console.log("[wrapper]", ...args);
+
+  // Helper to validate a wrapper address on-chain
+  const isValidWrapper = async (addr: `0x${string}`): Promise<boolean> => {
+    try {
+      const code = await publicClient.getBytecode({ address: addr });
+      if (!code) return false;
+      const superToken = getContract({ address: addr, abi: superTokenAbi, client: { public: publicClient } });
+      const underlying = await superToken.read.getUnderlyingToken();
+      return underlying.toLowerCase() === cfg.sendV1.toLowerCase();
+    } catch {
+      return false;
+    }
+  };
+
+  // 1) If deployments file has an address, attach if valid
+  if (existing?.address && existing.address !== "") {
+    const addr = existing.address as `0x${string}`;
+    if (await isValidWrapper(addr)) {
+      log("Found wrapper (deployments cache):", addr);
+      console.log(addr);
+      return;
+    }
+  }
+
+  // 2) Try canonical mapping in the factory
+  const factory = getContract({ address: cfg.superTokenFactory, abi: factoryAbi, client: { public: publicClient, wallet: walletClient } });
+  try {
+    const canonical = await factory.read.getCanonicalERC20Wrapper([cfg.sendV1]);
+    if (canonical && canonical !== "0x0000000000000000000000000000000000000000" && await isValidWrapper(canonical)) {
+      log("Found canonical wrapper:", canonical);
+      const block = await publicClient.getBlockNumber();
+      await writeJson(deploymentsPath, { address: canonical, underlying: cfg.sendV1, createdAt: Number(block), chainId, factory: cfg.superTokenFactory });
+      console.log(canonical);
+      return;
+    }
+  } catch (e) {
+    // Not all networks may have canonical entry initialized; continue to creation path if allowed
+    log("Canonical lookup skipped:", (e as Error).message);
+  }
+
+  // 3) Create wrapper if allowed
+  if (process.env.CREATE_WRAPPER !== "true") {
+    throw new Error("Wrapper not found. Set CREATE_WRAPPER=true to create it on this network.");
+  }
+
+  // Use simulate->write to capture return value (wrapper address) reliably.
+  // Upgradability: 1 = SEMI_UPGRADABLE (per SuperTokenFactory.Upgradability enum)
+  const upgradability = 1;
+  const { request, result: createdAddress } = await factory.simulate.createERC20Wrapper([
+    cfg.sendV1,
+    cfg.underlyingDecimals,
+    upgradability,
+    cfg.wrapperName,
+    cfg.wrapperSymbol,
+  ], { account });
+
+  const hash = await walletClient.writeContract(request);
+  const receipt = await publicClient.waitForTransactionReceipt({ hash });
+  log("createERC20Wrapper tx mined:", receipt.transactionHash);
+
+  const wrapperAddress = createdAddress as `0x${string}`;
+  if (!await isValidWrapper(wrapperAddress)) {
+    throw new Error(`Wrapper created but validation failed: ${wrapperAddress}`);
+  }
+
+  const block = await publicClient.getBlockNumber();
+  await writeJson(deploymentsPath, { address: wrapperAddress, underlying: cfg.sendV1, createdAt: Number(block), chainId, factory: cfg.superTokenFactory });
+  log("Wrapper created:", wrapperAddress);
+  console.log(wrapperAddress);
+}
+
+main().catch((err) => {
+  console.error("[wrapper] Error:", err);
+  process.exit(1);
+});
+


### PR DESCRIPTION
Why:
Automate discovery or creation of SENDx via SuperTokenFactory
use, mirroring official ABIs with viem+Hardhat.

Test plan:
- CREATE_WRAPPER=true bunx hardhat run scripts/wrapper/create.ts --network anvil
- Verify deployments/wrapper.*.json updated.