### PR TITLE
Test wrapper metadata and upgrade/downgrade

### DIFF
--- a/test/wrapper.ts
+++ b/test/wrapper.ts
@@ -8,9 +8,9 @@ import {
 } from "@nomicfoundation/hardhat-toolbox-viem/network-helpers";
 
 // Official ABIs from Superfluid package (Rule 3: mirror official examples)
-import SuperTokenFactoryJson from "@superfluid-finance/ethereum-contracts/build/truffle/SuperTokenFactory.json";
-import ISuperTokenJson from "@superfluid-finance/ethereum-contracts/build/truffle/ISuperToken.json";
-import IERC20Json from "@superfluid-finance/ethereum-contracts/build/truffle/IERC20.json";
+import SuperTokenFactoryJson from "@superfluid-finance/ethereum-contracts/build/truffle/SuperTokenFactory.json" assert { type: "json" };
+import ISuperTokenJson from "@superfluid-finance/ethereum-contracts/build/truffle/ISuperToken.json" assert { type: "json" };
+import IERC20Json from "@superfluid-finance/ethereum-contracts/build/truffle/IERC20.json" assert { type: "json" };
 
 async function getWrapperAddress(): Promise<`0x${string}` | null> {
   const publicClient = await hre.viem.getPublicClient();
@@ -40,7 +40,7 @@ async function getWrapperAddress(): Promise<`0x${string}` | null> {
   try {
     const canonical = (await factory.read.getCanonicalERC20Wrapper([
       cfg.sendV1,
-    ])) as unknown as `0x${string}`;
+    ])) as `0x${string}`;
     if (canonical && canonical !== zeroAddress) return canonical;
   } catch {}
 
@@ -54,11 +54,11 @@ async function getWrapperAddress(): Promise<`0x${string}` | null> {
     const upgradability = 1; // SEMI_UPGRADABLE
     const { request, result } = await factoryWrite.simulate.createERC20Wrapper(
       [cfg.sendV1, cfg.underlyingDecimals, upgradability, cfg.wrapperName, cfg.wrapperSymbol],
-      { account: walletClient.account as any }
+      { account: walletClient.account! }
     );
     const hash = await walletClient.writeContract(request);
     await publicClient.waitForTransactionReceipt({ hash });
-    return result as unknown as `0x${string}`;
+    return result as `0x${string}`;
   }
 
   return null;
@@ -70,7 +70,7 @@ async function isValidWrapper(addr: `0x${string}`): Promise<boolean> {
   const cfg = getConfig(chainId);
   const superToken = getContract({ address: addr, abi: ISuperTokenJson.abi as any[], client: { public: publicClient } });
   try {
-    const underlying = (await superToken.read.getUnderlyingToken([])) as unknown as `0x${string}`;
+    const underlying = (await superToken.read.getUnderlyingToken()) as `0x${string}`;
     return underlying.toLowerCase() === cfg.sendV1.toLowerCase();
   } catch { return false; }
 }
@@ -90,18 +90,16 @@ describe("SuperToken wrapper (backend-only)", () => {
 
     const superToken = getContract({ address: addr!, abi: ISuperTokenJson.abi as any[], client: { public: publicClient } });
     const [name, symbol, decimals, underlying] = await Promise.all([
-      superToken.read.name([]),
-      superToken.read.symbol([]),
-      superToken.read.decimals([]),
-      superToken.read.getUnderlyingToken([]),
+      superToken.read.name(),
+      superToken.read.symbol(),
+      superToken.read.decimals(),
+      superToken.read.getUnderlyingToken(),
     ]);
 
     expect(name).to.be.a("string");
     expect(symbol).to.be.a("string");
-    const decimalsNum = Number(decimals as any);
-    expect(decimalsNum).to.equal(18);
-    const underlyingAddr = underlying as unknown as `0x${string}`;
-    expect(underlyingAddr.toLowerCase()).to.equal(cfg.sendV1.toLowerCase());
+    expect(decimals).to.equal(18n);
+    expect((underlying as string).toLowerCase()).to.equal(cfg.sendV1.toLowerCase());
   });
 
   it("upgrade and downgrade round-trip (gated by SEND_HOLDER)", async function () {
@@ -111,9 +109,6 @@ describe("SuperToken wrapper (backend-only)", () => {
     }
 
     const publicClient = await hre.viem.getPublicClient();
-    const [walletClient] = await hre.viem.getWalletClients();
-    if (!walletClient) this.skip();
-
     const chainId = await publicClient.getChainId();
     const cfg = getConfig(chainId);
 
@@ -126,41 +121,35 @@ describe("SuperToken wrapper (backend-only)", () => {
     await impersonateAccount(holder!);
     await setBalance(holder!, 10n * 10n ** 18n);
 
-    const superToken = getContract({ address: addr!, abi: ISuperTokenJson.abi as any[], client: { public: publicClient, wallet: walletClient } });
-    const underlying = getContract({ address: cfg.sendV1, abi: IERC20Json.abi as any[], client: { public: publicClient, wallet: walletClient } });
+    const superToken = getContract({ address: addr!, abi: ISuperTokenJson.abi as any[], client: { public: publicClient } });
+    const underlying = getContract({ address: cfg.sendV1, abi: IERC20Json.abi as any[], client: { public: publicClient } });
 
     // amount = 1e18
     const amount = 10n ** 18n;
 
-    const [u0Raw, s0Raw] = await Promise.all([
-      underlying.read.balanceOf([holder!]),
-      superToken.read.balanceOf([holder!]),
+    const [u0, s0] = await Promise.all([
+      underlying.read.balanceOf([holder!]) as Promise<bigint>,
+      superToken.read.balanceOf([holder!]) as Promise<bigint>,
     ]);
-    const u0 = u0Raw as unknown as bigint;
-    const s0 = s0Raw as unknown as bigint;
 
     // Approve wrapper and upgrade
     await underlying.write.approve([addr!, amount], { account: holder! });
     await superToken.write.upgrade([amount], { account: holder! });
 
-    const [u1Raw, s1Raw] = await Promise.all([
-      underlying.read.balanceOf([holder!]),
-      superToken.read.balanceOf([holder!]),
+    const [u1, s1] = await Promise.all([
+      underlying.read.balanceOf([holder!]) as Promise<bigint>,
+      superToken.read.balanceOf([holder!]) as Promise<bigint>,
     ]);
-    const u1 = u1Raw as unknown as bigint;
-    const s1 = s1Raw as unknown as bigint;
 
     expect(u1).to.equal(u0 - amount);
     expect(s1).to.equal(s0 + amount);
 
     // Downgrade back
     await superToken.write.downgrade([amount], { account: holder! });
-    const [u2Raw, s2Raw] = await Promise.all([
-      underlying.read.balanceOf([holder!]),
-      superToken.read.balanceOf([holder!]),
+    const [u2, s2] = await Promise.all([
+      underlying.read.balanceOf([holder!]) as Promise<bigint>,
+      superToken.read.balanceOf([holder!]) as Promise<bigint>,
     ]);
-    const u2 = u2Raw as unknown as bigint;
-    const s2 = s2Raw as unknown as bigint;
 
     expect(u2).to.equal(u0);
     expect(s2).to.equal(s0);
@@ -180,17 +169,11 @@ describe("SuperToken wrapper (backend-only)", () => {
 
     // We only validate that contracts are callable; full flow creation is environment-sensitive and
     // should be exercised in dedicated integration runs.
-    // Static imports for ABIs
-    // eslint-disable-next-line @typescript-eslint/no-var-requires
-    const ISuperfluidJson = await import("@superfluid-finance/ethereum-contracts/build/truffle/ISuperfluid.json");
-    // eslint-disable-next-line @typescript-eslint/no-var-requires
-    const IConstantFlowAgreementV1Json = await import("@superfluid-finance/ethereum-contracts/build/truffle/IConstantFlowAgreementV1.json");
-
-    const host = getContract({ address: cfg.host, abi: (ISuperfluidJson as any).default.abi as any[], client: { public: publicClient } });
-    const cfa = getContract({ address: cfg.cfaV1, abi: (IConstantFlowAgreementV1Json as any).default.abi as any[], client: { public: publicClient } });
+    const host = getContract({ address: cfg.host, abi: (await import("@superfluid-finance/ethereum-contracts/build/truffle/ISuperfluid.json", { assert: { type: "json" } })).default.abi as any[], client: { public: publicClient } });
+    const cfa = getContract({ address: cfg.cfaV1, abi: (await import("@superfluid-finance/ethereum-contracts/build/truffle/IConstantFlowAgreementV1.json", { assert: { type: "json" } })).default.abi as any[], client: { public: publicClient } });
 
     // Basic read calls as smoke checks
-    const hostAddress = await host.read.getCodeAddress([]).catch(() => cfg.host);
+    const hostAddress = await host.read.getCodeAddress().catch(() => cfg.host);
     expect((hostAddress as string).toLowerCase()).to.be.a("string");
 
     // Encode a getFlow call as a non-mutating check (won't throw)


### PR DESCRIPTION
Why:
Validate wrapper metadata and gated upgrade/downgrade flow;
optionally smoke CFA lifecycle on Base fork.

Test plan:
- bunx hardhat test test/wrapper.ts
- Optional: set RUN_CFA_SMOKE=true to enable smoke.