### PR TITLE
Ensure hardfork=cancun on hardhat network

### DIFF
--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -10,6 +10,7 @@ const config: HardhatUserConfig = {
     // base mainnet network
     hardhat: {
       chainId: 8453,
+      hardfork: "cancun",
       forking: {
         url: "https://mainnet.base.org",
       },


### PR DESCRIPTION
Why:
Avoid mismatches in EVM behavior across local networks.

Test plan:
- Inspect hardhat.config.ts for hardfork=cancun.
- bunx hardhat compile works.