### PR TITLE
Add mocks: ERC20, ERC4626 vault, SendEarnFactory

### DIFF
--- a/contracts/mocks/MockERC20.sol
+++ b/contracts/mocks/MockERC20.sol
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+contract MockERC20 {
+    string public name;
+    string public symbol;
+    uint8 public immutable decimals;
+    mapping(address => uint256) public balanceOf;
+
+    constructor(string memory _name, string memory _symbol, uint8 _decimals) {
+        name = _name;
+        symbol = _symbol;
+        decimals = _decimals;
+    }
+
+    function mint(address to, uint256 amount) external {
+        balanceOf[to] += amount;
+    }
+}
+

--- a/contracts/mocks/MockERC4626Vault.sol
+++ b/contracts/mocks/MockERC4626Vault.sol
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+interface IERC4626Minimal {
+    function asset() external view returns (address);
+    function convertToAssets(uint256 shares) external view returns (uint256);
+    function balanceOf(address account) external view returns (uint256);
+}
+
+contract MockERC4626Vault is IERC4626Minimal {
+    address public immutable override asset;
+
+    string public name;
+    string public symbol;
+
+    mapping(address => uint256) public override balanceOf;
+
+    // ratio numerator/denominator for shares->assets conversion
+    uint256 public immutable ratioNum;
+    uint256 public immutable ratioDen;
+
+    constructor(address _asset, string memory _name, string memory _symbol, uint256 _ratioNum, uint256 _ratioDen) {
+        require(_asset != address(0), "asset");
+        require(_ratioNum > 0 && _ratioDen > 0, "ratio");
+        asset = _asset;
+        name = _name;
+        symbol = _symbol;
+        ratioNum = _ratioNum;
+        ratioDen = _ratioDen;
+    }
+
+    function mint(address to, uint256 shares) external {
+        balanceOf[to] += shares;
+    }
+
+    function convertToAssets(uint256 shares) external view override returns (uint256) {
+        return shares * ratioNum / ratioDen;
+    }
+}
+

--- a/contracts/mocks/MockSendEarnFactory.sol
+++ b/contracts/mocks/MockSendEarnFactory.sol
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+interface IMinimalSendEarnFactory {
+    function isSendEarn(address target) external view returns (bool);
+    function affiliates(address affiliate) external view returns (address);
+}
+
+contract MockSendEarnFactory is IMinimalSendEarnFactory {
+    mapping(address => bool) public isSendEarnMapping;
+    mapping(address => address) public affiliateToUnderlying;
+
+    function setIsSendEarn(address target, bool val) external {
+        isSendEarnMapping[target] = val;
+    }
+
+    function setAffiliate(address affiliate, address underlying) external {
+        affiliateToUnderlying[affiliate] = underlying;
+    }
+
+    function isSendEarn(address target) external view returns (bool) {
+        return isSendEarnMapping[target];
+    }
+
+    function affiliates(address affiliate) external view returns (address) {
+        return affiliateToUnderlying[affiliate];
+    }
+}
+


### PR DESCRIPTION
Why:
Provide minimal mocks to enable self-contained tests.

Test plan:
- bunx hardhat compile
- bunx hardhat test (mocks-related tests pass)