### PR TITLE
docs: remove commit SHAs from history sections

### DIFF
--- a/docs/platform.md
+++ b/docs/platform.md
@@ -94,7 +94,7 @@ Then test against the anvil network:
 
 ## Commit history (base → top)
 
-## 2ce849f Initialize README for SuperToken wrapper
+## Initialize README for SuperToken wrapper
 
 Why:
 Introduce initial README to describe the SuperToken wrapper
@@ -103,9 +103,8 @@ and repository scope so contributors have context.
 Test plan:
 - Open README.md and verify content renders.
 
-Commit: 2ce849f
 
-## af49ed5 Scaffold project from send-token-upgrade
+## Scaffold project from send-token-upgrade
 
 Why:
 Bootstrap repository structure using the known baseline to
@@ -115,9 +114,8 @@ Test plan:
 - List files; key scaffolding files exist.
 - bunx hardhat compile succeeds.
 
-Commit: af49ed5
 
-## 2334262 Rename package name
+## Rename package name
 
 Why:
 Ensure the package name matches the repository purpose and
@@ -127,9 +125,8 @@ Test plan:
 - Inspect package.json name field.
 - bun install completes without warnings.
 
-Commit: 2334262
 
-## 8f87619 Remove legacy lockbox code; rename Tilt resource
+## Remove legacy lockbox code; rename Tilt resource
 
 Why:
 Drop vestigial lockbox/v1 contracts not used here and keep
@@ -139,9 +136,8 @@ Test plan:
 - Confirm removed contracts no longer exist.
 - Tilt runs with updated resource names.
 
-Commit: 8f87619
 
-## 4440c4a Bootstrap Superfluid config and deployments
+## Bootstrap Superfluid config and deployments
 
 Why:
 Establish the network configuration and deterministic deploy
@@ -162,9 +158,8 @@ Test plan:
 - bunx hardhat run scripts/wrapper/create.ts --network base|sepolia
   (read-only discovery path)
 
-Commit: 4440c4a
 
-## 0d00a52 Add Superfluid ABIs helper
+## Add Superfluid ABIs helper
 
 Why:
 Centralize ABI references used by scripts to avoid drift and
@@ -174,9 +169,8 @@ Test plan:
 - Inspect scripts/abis/superfluid.ts.
 - Run wrapper/rewards scripts without ABI errors.
 
-Commit: 0d00a52
 
-## 9f22c5a Add CFAv1Forwarder field (optional)
+## Add CFAv1Forwarder field (optional)
 
 Why:
 Expose forwarder address for optional streaming helpers and
@@ -185,9 +179,8 @@ integration tests.
 Test plan:
 - Inspect config/superfluid.ts includes forwarder.
 
-Commit: 9f22c5a
 
-## 3e706dd Add test/type dependencies and refresh bun.lock
+## Add test/type dependencies and refresh bun.lock
 
 Why:
 Provide required types and keep lockfile up to date to avoid
@@ -197,9 +190,8 @@ Test plan:
 - bun install succeeds.
 - Type checks pass.
 
-Commit: 3e706dd
 
-## f98498d Ensure hardfork=cancun on hardhat network
+## Ensure hardfork=cancun on hardhat network
 
 Why:
 Avoid mismatches in EVM behavior across local networks.
@@ -208,9 +200,8 @@ Test plan:
 - Inspect hardhat.config.ts for hardfork=cancun.
 - bunx hardhat compile works.
 
-Commit: f98498d
 
-## f81d703 Align viem calls and env discovery in tests
+## Align viem calls and env discovery in tests
 
 Why:
 Reduce flakiness and ensure tests resolve env/config in a
@@ -220,9 +211,8 @@ Test plan:
 - bunx hardhat test test/rewards.manager.test.ts
 - bunx hardhat test test/wrapper.ts
 
-Commit: f81d703
 
-## bfc0b68 Add SuperTokenV1Library notes and update docs
+## Add SuperTokenV1Library notes and update docs
 
 Why:
 Record library usage patterns and refine project planning
@@ -231,9 +221,8 @@ documents for clarity.
 Test plan:
 - Open SuperTokenV1Library.md and PLAN.md.
 
-Commit: bfc0b68
 
-## 0bd7274 Split docs into feature docs; remove stack-plan
+## Split docs into feature docs; remove stack-plan
 
 Why:
 Move documentation from docs/stack-plan.md into per-feature docs to
@@ -246,5 +235,4 @@ Test plan:
 - Confirm docs/stack-plan.md has been removed and README links to feature
   docs.
 
-Commit: 0bd7274
 

--- a/docs/rewards.md
+++ b/docs/rewards.md
@@ -39,7 +39,7 @@
 
 ## Commit history (base → top)
 
-## 07e36a2 Add RewardsManager plan doc
+## Add RewardsManager plan doc
 Why:
 Capture scope and strategy for RewardsManager to align on
 pool creation and unit sync behavior.
@@ -47,9 +47,8 @@ pool creation and unit sync behavior.
 Test plan:
 - Open docs/rewards/PLAN.md; verify content.
 
-Commit: 07e36a2
 
-## 0fc4d93 Add RewardsManager for pool units sync
+## Add RewardsManager for pool units sync
 Why:
 Create minimal manager to mirror ERC-4626 asset balances to
 Superfluid pool units.
@@ -58,12 +57,10 @@ Test plan:
 - bunx hardhat compile
 - bunx hardhat test test/rewards.manager.test.ts
 
-Commit: 0fc4d93
 
-## 2bf288a script: rewards deploy (resolve sendx/share, require pool addr)
-Commit: 2bf288a
+## script: rewards deploy (resolve sendx/share, require pool addr)
 
-## 86acc12 Add rewards deploy script and pool requirements
+## Add rewards deploy script and pool requirements
 Why:
 Automate deployment around SENDx/Share discovery and require
 pool address persistence.
@@ -72,9 +69,8 @@ Test plan:
 - bunx hardhat run scripts/rewards/deploy.ts --network anvil
 - Verify deployments/rewards.*.json written.
 
-Commit: 86acc12
 
-## 472d60d Require existing SENDx in RewardsManager constructor
+## Require existing SENDx in RewardsManager constructor
 Why:
 Decouple wrapper creation from rewards by requiring an existing
 ISuperToken (SENDx) to be passed into the RewardsManager
@@ -87,9 +83,8 @@ Test plan:
 - bunx hardhat run scripts/rewards/deploy.ts --network anvil
   (SENDx resolved; pool is created; deployments updated)
 
-Commit: 472d60d
 
-## 7509f03 Require existing SENDx and persist in deployments
+## Require existing SENDx and persist in deployments
 Why:
 Ensure deployments include SENDx and pass it into manager for
 consistent wiring.
@@ -98,9 +93,8 @@ Test plan:
 - Run deploy script on anvil.
 - Check deployments JSON includes sendx.
 
-Commit: 7509f03
 
-## 2a9d0b3 Test passing SENDx to RewardsManager
+## Test passing SENDx to RewardsManager
 Why:
 Ensure tests reuse wrapper resolution patterns and pass SENDx
 to the manager.
@@ -108,9 +102,8 @@ to the manager.
 Test plan:
 - bunx hardhat test test/rewards.normalize.test.ts
 
-Commit: 2a9d0b3
 
-## 3d0fc4f Update docs: manager requires existing SuperToken
+## Update docs: manager requires existing SuperToken
 Why:
 Reflect that the RewardsManager constructor requires an
 existing SENDx; update README and WARP accordingly.
@@ -118,9 +111,8 @@ existing SENDx; update README and WARP accordingly.
 Test plan:
 - Render README and WARP; verify updated instructions.
 
-Commit: 3d0fc4f
 
-## 9cc1468 Update Ignition module and params to use SENDx
+## Update Ignition module and params to use SENDx
 Why:
 Bring Ignition deployment inputs in line with the new manager
 constructor contract.
@@ -128,9 +120,8 @@ constructor contract.
 Test plan:
 - Run ignition deploy with SENDx parameter set.
 
-Commit: 9cc1468
 
-## 2567ed4 Cache deployments and add artifacts for manager
+## Cache deployments and add artifacts for manager
 Why:
 Speed local workflows by caching deployments and providing
 compiled artifacts for tests/scripts.
@@ -139,9 +130,8 @@ Test plan:
 - Verify deployments written.
 - bun run test completes.
 
-Commit: 2567ed4
 
-## 32ac7ed Add fundHolder helper to deposit and mint shares
+## Add fundHolder helper to deposit and mint shares
 Why:
 Enable local fork testing by funding a holder via scripted
 deposits and share mints.
@@ -149,9 +139,8 @@ deposits and share mints.
 Test plan:
 - bunx hardhat run scripts/rewards/fundHolder.ts --network anvil
 
-Commit: 32ac7ed
 
-## a1f1115 Add mocks: ERC20, ERC4626 vault, SendEarnFactory
+## Add mocks: ERC20, ERC4626 vault, SendEarnFactory
 Why:
 Provide minimal mocks to enable self-contained tests.
 
@@ -159,9 +148,8 @@ Test plan:
 - bunx hardhat compile
 - bunx hardhat test (mocks-related tests pass)
 
-Commit: a1f1115
 
-## 581b600 Enable streaming and wrapper upgrade in tests
+## Enable streaming and wrapper upgrade in tests
 Why:
 Now that approve exists on MockERC20, enable streaming tests
 and local wrapper upgrade flows.
@@ -170,9 +158,8 @@ Test plan:
 - bunx hardhat test test/rewards.streaming.test.ts
 - bunx hardhat test test/wrapper.ts
 
-Commit: 581b600
 
-## 0bd7274 Split docs into feature docs; remove stack-plan
+## Split docs into feature docs; remove stack-plan
 
 Why:
 Move documentation from docs/stack-plan.md into per-feature docs to
@@ -185,5 +172,4 @@ Test plan:
 - Confirm docs/stack-plan.md has been removed and README links to feature
   docs.
 
-Commit: 0bd7274
 

--- a/docs/wrapper.md
+++ b/docs/wrapper.md
@@ -20,7 +20,7 @@
 
 ## Commit history (base → top)
 
-## c9ac731 Add SuperToken wrapper plan
+## Add SuperToken wrapper plan
 Why:
 Document the intended wrapper strategy and constraints to
 align contributors and future work.
@@ -28,9 +28,8 @@ align contributors and future work.
 Test plan:
 - Open PLAN.md and verify plan sections are present.
 
-Commit: c9ac731
 
-## 227ab14 Add wrapper create/attach script
+## Add wrapper create/attach script
 Why:
 Automate discovery or creation of SENDx via SuperTokenFactory
 use, mirroring official ABIs with viem+Hardhat.
@@ -39,9 +38,8 @@ Test plan:
 - CREATE_WRAPPER=true bunx hardhat run scripts/wrapper/create.ts --network anvil
 - Verify deployments/wrapper.*.json updated.
 
-Commit: 227ab14
 
-## 9e616e3 Validate wrapper metadata and upgrade/downgrade; optional CFA smoke
+## Validate wrapper metadata and upgrade/downgrade; optional CFA smoke
 Why:
 Ensure the SENDx wrapper is correct and usable. Verify name,
 symbol, and decimals; exercise upgrade/downgrade round‑trip
@@ -53,9 +51,8 @@ Test plan:
 - bunx hardhat test test/wrapper.ts
 - Optional: RUN_CFA_SMOKE=true bunx hardhat test test/wrapper.ts
 
-Commit: 9e616e3
 
-## 6c02f37 Wire anvil-deploy to wrapper script; set signer
+## Wire anvil-deploy to wrapper script; set signer
 Why:
 Make local orchestration run wrapper creation with the anvil
 signer sourced from EOA_DEPLOYER for consistency.
@@ -64,9 +61,8 @@ Test plan:
 - ./bin/anvil-deploy on a Base fork.
 - Observe wrapper create/attach steps succeed.
 
-Commit: 6c02f37
 
-## f44d3af Add UNDERLYING_ADDRESS override for wrapper
+## Add UNDERLYING_ADDRESS override for wrapper
 Why:
 Allow overriding the underlying token address while keeping
 canonical/create validation flow.
@@ -75,18 +71,16 @@ Test plan:
 - Run scripts/wrapper/create.ts with override.
 - Verify underlying matches configured address.
 
-Commit: f44d3af
 
-## 9350fa9 Update wrapper cache for anvil (845337)
+## Update wrapper cache for anvil (845337)
 Why:
 Keep local wrapper address cache in sync with current fork.
 
 Test plan:
 - Inspect deployments/wrapper.845337.json.
 
-Commit: 9350fa9
 
-## 0bd7274 Split docs into feature docs; remove stack-plan
+## Split docs into feature docs; remove stack-plan
 
 Why:
 Move documentation from docs/stack-plan.md into per-feature docs to
@@ -99,5 +93,4 @@ Test plan:
 - Confirm docs/stack-plan.md has been removed and README links to feature
   docs.
 
-Commit: 0bd7274
 


### PR DESCRIPTION
Embedded short SHAs in docs cause churn whenever the stack is
restacked or amended. Removing these tokens avoids unnecessary diffs
and broken anchors while preserving human-readable subject lines.

Scope:
- Delete footer lines that are exactly "Commit: " followed by 7–40 hex.
- Strip leading short SHAs from "##" section headings so headings keep
  only the subject.
- Only files under docs/*.md are edited. No code changes.

Stable diff pointers (for future readers):
- Prefer a GitHub compare URL anchored to branch names:
  https://github.com/ORG/REPO/compare/BASE_BRANCH...TOPIC_BRANCH
- Or the PR URL (stable over time).

Test plan:
- Verify removal:
  grep -R -nE '(^Commit: [0-9a-fA-F]{7,40}$)|(^## [0-9a-fA-F]{7,40}\b)' docs || echo "No SHA/Commit lines remain"
- Confirm scope:
  git --no-pager diff --name-only --cached | xargs -I{} bash -lc '[[ "{}" == docs/* ]] && echo OK: {}'
- Render docs; headings show subjects without SHAs.