### PR TITLE
Add ERC4626 v2 tests (routing, transfers, no-loop withdraws)

### DIFF
--- a/contracts/mocks/SendEarnFactoryAffiliatesMock.sol
+++ b/contracts/mocks/SendEarnFactoryAffiliatesMock.sol
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+// Test-only mock that mirrors the minimal surface we need from ISendEarnFactory for v2 routing tests.
+// Source of truth (example used): send-earn-contracts/src/interfaces/ISendEarnFactory.sol
+// Correlation: exposes affiliates(address)->address, isSendEarn(address)->bool, and SEND_EARN()->address
+// to drive routing decisions in tests without importing full factory code.
+
+interface IMinimalFactoryLike {
+    function isSendEarn(address target) external view returns (bool);
+    function affiliates(address who) external view returns (address);
+    function SEND_EARN() external view returns (address);
+}
+
+contract SendEarnFactoryAffiliatesMock is IMinimalFactoryLike {
+    mapping(address => bool) public override isSendEarn;
+    mapping(address => address) public override affiliates;
+    address public override SEND_EARN;
+
+    function setIsSendEarn(address target, bool allowed) external {
+        isSendEarn[target] = allowed;
+    }
+
+    function setAffiliate(address who, address vault) external {
+        affiliates[who] = vault;
+    }
+
+    function setSendEarn(address vault) external {
+        SEND_EARN = vault;
+    }
+}

--- a/test/rewards/SendEarnRewards.erc4626.spec.ts
+++ b/test/rewards/SendEarnRewards.erc4626.spec.ts
@@ -1,0 +1,44 @@
+import { expect } from "chai";
+import hre from "hardhat";
+
+// v2 ERC4626 Aggregator tests (streaming deferred)
+// Intent: outline domain behavior; many cases are pending until the implementation is rewritten.
+// Template sources used (no blind code):
+// - Existing spec structure: super-send-token/test/rewards/SendEarnRewards.spec.ts
+// - Factory interface semantics: send-earn-contracts/src/interfaces/ISendEarnFactory.sol
+// - Vault mocks: super-send-token/contracts/mocks/MinimalVault.sol (ERC4626TestVault)
+
+describe("SendEarnRewards v2 (ERC4626 only; streaming deferred)", () => {
+  it.skip("routes deposit to affiliates(caller) when set; otherwise prefers default SEND_EARN if caller already holds default shares", async function () {
+    // Pending: requires v2 implementation (no CFA calls in hooks) and a factory mock exposing affiliates() and SEND_EARN().
+    // Outline:
+    // - Deploy ERC20Mintable (underlying)
+    // - Deploy 2 ERC4626TestVaults (affiliateVault, defaultVault)
+    // - Deploy SendEarnFactoryAffiliatesMock
+    // - Set isSendEarn for both vaults; set SEND_EARN = defaultVault; set affiliates[user] = affiliateVault
+    // - Deploy v2 aggregator (asset = underlying)
+    // - Approve+deposit X assets via aggregator → expect aggregator to hold shares in affiliateVault
+    // - Clear affiliates[user]; give user direct seUSDC in defaultVault; deposit again → expect route to defaultVault
+  });
+
+  it.skip("shares are transferable (no non-transferable override)", async function () {
+    // Pending: current implementation overrides _update to disallow transfers.
+    // Outline:
+    // - Mint aggregator shares to user (via deposit)
+    // - transfer to other user → should succeed
+  });
+
+  it.skip("totalAssets equals the sum over held SendEarn vault positions converted via convertToAssets", async function () {
+    // Pending: current implementation uses 1:1 accounting; v2 should compute sum over held vaults.
+    // Outline:
+    // - After routing deposits to two vaults, read totalAssets and compare to per-vault convertToAssets balances
+  });
+
+it.skip("withdraw uses only the resolved vault and reverts if insufficient (no loops)", async function () {
+    // Gas-efficient policy: no multi-vault loops in withdraw.
+    // Outline:
+    // - With positions in two vaults (historical deposits), set affiliates(owner) to affiliateVault so it resolves there
+    // - Attempt withdraw X where affiliateVault can fully satisfy → succeeds and only that vault’s position decreases
+    // - Attempt withdraw Y where affiliateVault cannot satisfy → expect revert (no fallback loop into other vault)
+  });
+});


### PR DESCRIPTION
Why:
Outline the v2 aggregator behavior with gas-efficient, single-vault withdraws.
Templates used:
- test/rewards/SendEarnRewards.spec.ts (structure)
- send-earn-contracts/src/interfaces/ISendEarnFactory.sol (affiliates/SEND_EARN)
- contracts/mocks/MinimalVault.sol (ERC4626TestVault)

Test plan:
- Specs are skipped until implementation; compilation should succeed