### PR TITLE
Tests: prepare for ERC4626 composability (NAV-based); remove 1:1 assumptions

### DIFF
--- a/docs/rewards-aggregator-erc4626.md
+++ b/docs/rewards-aggregator-erc4626.md
@@ -14,7 +14,53 @@ Status: Spec only (docs-first). Implementation and tests will follow in separate
 - Active vaults (wrapper-wide): first time a deposit is made into a vault, it’s added to `_activeVaults` for view-only `totalAssets()`.
 - Active vaults (per-user): first time a user receives underlying shares for a vault, it’s added to that user’s active set for proportional re‑attribution on ERC20 transfers (no external calls).
 
-## Asset and conversions
+## Asset, conversions, and NAV-based accounting (v2.0)
+- ERC4626 aggregator with `asset()` equal to the underlying asset used by all SendEarn vaults (e.g., USDC).
+- NAV-based share pricing (standard ERC4626 math): aggregator shares represent a pro‑rata claim on the total aggregated assets held via SendEarn vault shares.
+- Conversions (no 1:1 simplification):
+  - `totalAssets()` equals the sum, over all tracked vaults `v`, of `IERC4626(v).convertToAssets(IERC4626(v).balanceOf(address(this)))`.
+  - `_convertToShares(assets)` and `_convertToAssets(shares)` use standard ERC4626 formulas based on current `totalAssets()` and `totalSupply()`.
+
+### Deposit interfaces
+There are two complementary ways to contribute value:
+
+1) Ingest existing SendEarn vault shares (non‑standard): `depositVaultShares(vault, shares)`
+   - Preconditions: `factory.isSendEarn(vault)` and `IERC4626(vault).asset() == asset()`.
+   - Flow:
+     1) Pull `shares` from the user into the aggregator (transferFrom)
+     2) `assetsEq = IERC4626(vault).convertToAssets(shares)`
+     3) Mint aggregator shares using NAV: `minted = _convertToShares(assetsEq, …)`
+     4) Per‑user ledger: `_userUnderlyingShares[user][vault] += shares`
+     5) Track vault in `_activeVaults` if first use
+     6) Emit `Deposited(user, vault, assetsEq, shares)`
+
+2) Standard ERC4626 deposit of underlying: `deposit(assets, receiver)`
+   - Resolution: `vault = affiliates(receiver)` if non‑zero else `SEND_EARN()`
+   - Flow:
+     1) Mint aggregator shares using NAV: `minted = _convertToShares(assets, …)`
+     2) Aggregator deposits `assets` into `vault`, receiving `vaultShares`
+     3) Per‑user ledger: `_userUnderlyingShares[receiver][vault] += vaultShares`
+     4) Track vault in `_activeVaults` if first use
+     5) Emit `Deposited(receiver, vault, assets, vaultShares)`
+
+### Withdraw and Redeem (single‑vault, no loops)
+- `withdraw(assets, receiver, owner)`
+  - `vault = affiliates(owner)` if non‑zero else `SEND_EARN()`
+  - `sharesNeeded = IERC4626(vault).previewWithdraw(assets)`
+  - Require `_userUnderlyingShares[owner][vault] >= sharesNeeded`
+  - Redeem `sharesNeeded` from `vault` to the aggregator, then send `assets` to `receiver`
+  - Burn aggregator shares using NAV: `_convertToShares(assets, …)`
+  - `_userUnderlyingShares[owner][vault] -= sharesNeeded`
+  - Emit `Withdrawn(owner, vault, assets, sharesNeeded)`
+
+- `redeem(shares, receiver, owner)`
+  - Resolve `vault` as above
+  - Redeem underlying vault shares sufficient to produce `assetsOut`, send to `receiver`
+  - Update per‑user ledger and burn aggregator shares using NAV
+
+### Transfers
+- ERC20 transfers of aggregator shares DO NOT modify per‑user underlying ledgers.
+- Flows (CFA) are updated only on deposit/withdraw/redeem (see CFA v2.1).
 - The aggregator’s `asset()` equals the underlying asset used by all routed SendEarn vaults (e.g., USDC).
 - Follow standard ERC4626 math for conversions; do not assume 1:1 shares/assets. `totalAssets()` reflects the current value of all held SendEarn vault shares converted via each vault’s `convertToAssets`.
 
@@ -55,9 +101,10 @@ All routed targets MUST satisfy:
 
 ## Total assets (view-only)
 - `totalAssets()` sums across wrapper-held positions:
-  - For each tracked vault v in `_activeVaults`:
+  - For each tracked vault `v` in `_activeVaults`:
     - `assets += IERC4626(v).convertToAssets(IERC4626(v).balanceOf(address(this)))`
 - This is a view-only iteration. State-changing flows remain single-vault without loops.
+- Conversions use NAV (no 1:1 shortcut).
 
 ## CFA streaming integration (v2.1) — Professional spec
 

--- a/test/rewards/SendEarnRewards.erc4626.spec.ts
+++ b/test/rewards/SendEarnRewards.erc4626.spec.ts
@@ -61,11 +61,12 @@ describe("SendEarnRewards v2 (ERC4626 only; streaming deferred)", () => {
     await userA.writeContract({ address: factory.address, abi: (await hre.artifacts.readArtifact("SendEarnFactoryAffiliatesMock")).abi as any, functionName: "setAffiliate", args: [a, vaultA.address] });
 
     const assets = 200n * 10n ** 18n;
+    const expMint = await pub.readContract({ address: rewards.address, abi: (await hre.artifacts.readArtifact("SendEarnRewards")).abi as any, functionName: "previewDeposit", args: [assets] });
     await userA.writeContract({ address: rewards.address, abi: (await hre.artifacts.readArtifact("SendEarnRewards")).abi as any, functionName: "deposit", args: [assets, a] });
 
-    // Wrapper shares 1:1
+    // Wrapper shares minted per ERC4626 NAV (not 1:1)
     const bal = await pub.readContract({ address: rewards.address, abi: (await hre.artifacts.readArtifact("SendEarnRewards")).abi as any, functionName: "balanceOf", args: [a] });
-    expect(bal).to.equal(assets);
+    expect(bal).to.equal(expMint);
 
     // Underlying shares recorded
     const underlyingShares: bigint = await pub.readContract({ address: rewards.address, abi: (await hre.artifacts.readArtifact("SendEarnRewards")).abi as any, functionName: "userUnderlyingShares", args: [a, vaultA.address] });
@@ -100,10 +101,12 @@ describe("SendEarnRewards v2 (ERC4626 only; streaming deferred)", () => {
 
     // Set affiliate back to vaultA and withdraw 40 (single vault)
     await userA.writeContract({ address: factory.address, abi: (await hre.artifacts.readArtifact("SendEarnFactoryAffiliatesMock")).abi as any, functionName: "setAffiliate", args: [a, vaultA.address] });
+    const burnShares = await pub.readContract({ address: rewards.address, abi: (await hre.artifacts.readArtifact("SendEarnRewards")).abi as any, functionName: "previewWithdraw", args: [40n * 10n ** 18n] });
+    const balBefore = await pub.readContract({ address: rewards.address, abi: (await hre.artifacts.readArtifact("SendEarnRewards")).abi as any, functionName: "balanceOf", args: [a] });
     await userA.writeContract({ address: rewards.address, abi: (await hre.artifacts.readArtifact("SendEarnRewards")).abi as any, functionName: "withdraw", args: [40n * 10n ** 18n, a, a] });
 
     const balAfter = await pub.readContract({ address: rewards.address, abi: (await hre.artifacts.readArtifact("SendEarnRewards")).abi as any, functionName: "balanceOf", args: [a] });
-    expect(balAfter).to.equal(depositAmt - 40n * 10n ** 18n);
+    expect(balBefore - balAfter).to.equal(burnShares);
   });
 
   it("totalAssets equals sum over tracked vaults convertToAssets(wrapper-held shares)", async () => {
@@ -131,7 +134,7 @@ describe("SendEarnRewards v2 (ERC4626 only; streaming deferred)", () => {
     expect(total).to.equal((assetsA as bigint) + (assetsB as bigint));
   });
 
-  it("transfers re-attribute underlying shares proportionally across sender's active vaults", async () => {
+  it("transfers do not modify per-user underlying ledgers", async () => {
     const { pub, deployer, userA, userB, erc20, vaultA, factory, rewards } = await deployFixture();
     const a = userA.account!.address as `0x${string}`;
     const b = userB.account!.address as `0x${string}`;
@@ -151,18 +154,38 @@ describe("SendEarnRewards v2 (ERC4626 only; streaming deferred)", () => {
     const xfer = 120n * 10n ** 18n;
     await userA.writeContract({ address: rewards.address, abi: (await hre.artifacts.readArtifact("SendEarnRewards")).abi as any, functionName: "transfer", args: [b, xfer] });
 
-    const moved = (fromUnderlyingBefore as bigint) * xfer / (senderSharesBefore as bigint);
     const fromUnderlyingAfter = await pub.readContract({ address: rewards.address, abi: (await hre.artifacts.readArtifact("SendEarnRewards")).abi as any, functionName: "userUnderlyingShares", args: [a, vaultA.address] });
     const toUnderlyingAfter = await pub.readContract({ address: rewards.address, abi: (await hre.artifacts.readArtifact("SendEarnRewards")).abi as any, functionName: "userUnderlyingShares", args: [b, vaultA.address] });
 
-    expect((fromUnderlyingBefore as bigint) - (fromUnderlyingAfter as bigint)).to.equal(moved);
-    expect(toUnderlyingAfter).to.equal(moved);
+    // No change to per-user ledgers due to transfer
+    expect(fromUnderlyingAfter).to.equal(fromUnderlyingBefore);
+    expect(toUnderlyingAfter).to.equal(0n);
+  });
+  it("ingests existing SendEarn shares and mints aggregator shares per NAV", async () => {
+    const { pub, deployer, userA, erc20, vaultA, factory, rewards } = await deployFixture();
+    const a = userA.account!.address as `0x${string}`;
 
-    // Set affiliates(userB)=vaultA then withdraw a portion successfully
-    await userB.writeContract({ address: factory.address, abi: (await hre.artifacts.readArtifact("SendEarnFactoryAffiliatesMock")).abi as any, functionName: "setAffiliate", args: [b, vaultA.address] });
-    await userB.writeContract({ address: rewards.address, abi: (await hre.artifacts.readArtifact("SendEarnRewards")).abi as any, functionName: "withdraw", args: [20n * 10n ** 18n, b, b] });
+    // User acquires vaultA shares directly
+    await deployer.writeContract({ address: erc20.address, abi: (await hre.artifacts.readArtifact("ERC20Mintable")).abi as any, functionName: "mint", args: [a, 1_000n * 10n ** 18n] as any });
+    await userA.writeContract({ address: erc20.address, abi: (await hre.artifacts.readArtifact("ERC20Mintable")).abi as any, functionName: "approve", args: [vaultA.address, 600n * 10n ** 18n] });
+    const depositToVault = 250n * 10n ** 18n;
+    await userA.writeContract({ address: vaultA.address, abi: (await hre.artifacts.readArtifact("ERC4626TestVault")).abi as any, functionName: "deposit", args: [depositToVault, a] });
+    const userVaultShares = await pub.readContract({ address: vaultA.address, abi: (await hre.artifacts.readArtifact("ERC4626TestVault")).abi as any, functionName: "balanceOf", args: [a] });
 
-    const toBal = await pub.readContract({ address: rewards.address, abi: (await hre.artifacts.readArtifact("SendEarnRewards")).abi as any, functionName: "balanceOf", args: [b] });
-    expect(toBal).to.equal(xfer - 20n * 10n ** 18n);
+    // Approve aggregator to take vault shares
+    await userA.writeContract({ address: vaultA.address, abi: (await hre.artifacts.readArtifact("ERC4626TestVault")).abi as any, functionName: "approve", args: [rewards.address, userVaultShares] });
+
+    // Expected aggregator shares using NAV
+    const assetsEq = await pub.readContract({ address: vaultA.address, abi: (await hre.artifacts.readArtifact("ERC4626TestVault")).abi as any, functionName: "convertToAssets", args: [userVaultShares] });
+    const expMintAgg = await pub.readContract({ address: rewards.address, abi: (await hre.artifacts.readArtifact("SendEarnRewards")).abi as any, functionName: "previewDeposit", args: [assetsEq] });
+
+    // Ingest shares
+    await userA.writeContract({ address: rewards.address, abi: (await hre.artifacts.readArtifact("SendEarnRewards")).abi as any, functionName: "depositVaultShares", args: [vaultA.address, userVaultShares] });
+
+    const aggBal = await pub.readContract({ address: rewards.address, abi: (await hre.artifacts.readArtifact("SendEarnRewards")).abi as any, functionName: "balanceOf", args: [a] });
+    expect(aggBal).to.equal(expMintAgg);
+
+    const recordedShares = await pub.readContract({ address: rewards.address, abi: (await hre.artifacts.readArtifact("SendEarnRewards")).abi as any, functionName: "userUnderlyingShares", args: [a, vaultA.address] });
+    expect(recordedShares).to.equal(userVaultShares);
   });
 });


### PR DESCRIPTION
- Deposit mints per previewDeposit (NAV), not 1:1
- Withdraw burns per previewWithdraw and updates only resolved vault
- Transfers do not modify per-user ledgers
- totalAssets sums across tracked vaults
- Ingesting SendEarn shares mints aggregator shares per NAV

Test plan:
- Run: bunx hardhat test test/rewards/SendEarnRewards.erc4626.spec.ts